### PR TITLE
Add cli flag for offline

### DIFF
--- a/pkg/server/cli/clicontext.go
+++ b/pkg/server/cli/clicontext.go
@@ -18,6 +18,7 @@ type Config struct {
 	HTTPSListenPort int
 	HTTPListenPort  int
 	UIPath          string
+	Offline         string
 
 	WebhookConfig authcli.WebhookConfig
 }
@@ -69,6 +70,12 @@ func Flags(config *Config) []cli.Flag {
 		cli.StringFlag{
 			Name:        "ui-path",
 			Destination: &config.UIPath,
+		},
+		cli.StringFlag{
+			Name:        "offline",
+			Value:       "dynamic",
+			Usage:       "Determine whether or not to run the UI offline, accepts values true/false/dynamic",
+			Destination: &config.Offline,
 		},
 		cli.IntFlag{
 			Name:        "https-listen-port",

--- a/pkg/server/cli/clicontext.go
+++ b/pkg/server/cli/clicontext.go
@@ -51,7 +51,7 @@ func (c *Config) ToServer(ctx context.Context) (*server.Server, error) {
 
 	return server.New(ctx, restConfig, &server.Options{
 		AuthMiddleware: auth,
-		Next:           ui.New(c.UIPath),
+		Next:           ui.New(c.UIPath, c.Offline),
 	})
 }
 

--- a/pkg/ui/routes.go
+++ b/pkg/ui/routes.go
@@ -7,13 +7,23 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func New(path string) http.Handler {
+func New(path string, offline string) http.Handler {
 	vue := NewUIHandler(&Options{
 		Path: func() string {
 			if path == "" {
 				return defaultPath
 			}
 			return path
+		},
+		Offline: func() string {
+			switch offline {
+			case
+				"true",
+				"false",
+				"dynamic":
+				return offline
+			}
+			return "dynamic"
 		},
 	})
 


### PR DESCRIPTION
This adds a cli flag for the offline config in the UI handler. I added this flag because Rancher Desktop is currently experimenting with embedding a Steve binary as a means to quickly add additional dashboard features. Our use case is that we want to assert that Steve will only ever use our own bundled version of dashboard without reaching out to releases.rancher.com.
