### PR TITLE
Fix dashboard rendering issue in Windows

### DIFF
--- a/pkg/ui/routes.go
+++ b/pkg/ui/routes.go
@@ -33,7 +33,8 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// prepend the path with the path to the static directory
-	path = filepath.Join(h.staticPath, path)
+	base := filepath.Base(path)
+	path = filepath.Join(h.staticPath, base)
 
 	// check whether a file exists at the given path
 	_, err = os.Stat(path)

--- a/pkg/ui/routes.go
+++ b/pkg/ui/routes.go
@@ -33,8 +33,7 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// prepend the path with the path to the static directory
-	base := filepath.Base(path)
-	path = filepath.Join(h.staticPath, base)
+	path = filepath.Join(h.staticPath, r.URL.Path)
 
 	// check whether a file exists at the given path
 	_, err = os.Stat(path)


### PR DESCRIPTION
The absolute path in Windows includes `C:\`, so this was causing our routes to fail after joining paths to get our resource. For example, an absolute path in Windows after join would be something like `C:\Users\prak\dev\rancher-desktop\resources\rancher-dashboard\C:\dashboard\c\local\explorer`

Just making use of the resource `URL.Path` seems to resolve the issue and behave as expected across Windows, macOS, and Linux.