### PR TITLE
Handle subscribe socket directly for local and not send 302

### DIFF
--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -33,6 +33,8 @@ func Routes(h Handlers) http.Handler {
 	m.Path("/v1/{type}/{namespace}/{name}").Queries("link", "{link}").Handler(h.K8sResource)
 	m.Path("/v1/{type}/{namespace}/{name}").Handler(h.K8sResource)
 	m.Path("/v1/{type}/{namespace}/{name}/{link}").Handler(h.K8sResource)
+	// This link is for a websocket which will not work with the 302 response sent in ui/routes.go
+	m.Path("/k8s/clusters/local/v1/{type:subscribe}").Handler(h.K8sResource)
 	m.Path("/api").Handler(h.K8sProxy) // Can't just prefix this as UI needs /apikeys path
 	m.PathPrefix("/api/").Handler(h.K8sProxy)
 	m.PathPrefix("/apis").Handler(h.K8sProxy)


### PR DESCRIPTION
This fix should be able to be upstreamed to Rancher because the /k8s/cluster/ path prefix is handles by the rancher router and not steve.  So the request will never hit this line

https://github.com/rancher-sandbox/rancher-desktop/issues/1887